### PR TITLE
Update pyproject.toml to fix license issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,10 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     "Operating System :: OS Independent",
+    "License :: OSI Approved :: MIT License",
 ]
-license = "MIT"
-license-files = ["LICENSE"]
+license = { file = "LICENSE" }
+
 
 [project.urls]
 repository = "https://github.com/AEFDI/EnergyFaultDetector"


### PR DESCRIPTION
As mentioned in the issue here
  https://github.com/AEFDI/EnergyFaultDetector/issues/3
on my freshly cloned repo (Linux Mint x64 default install) the pyproject.toml causes setup.py to not work until the lines regarding license are removed, commented out or replaced with the lines mentioned in the issue linked above.
To retain legal integrity, this is a fix of this problem that keeps the legal information intact.