### PR TITLE
Don't drop conditional features

### DIFF
--- a/energy_fault_detector/data_preprocessing/column_selector.py
+++ b/energy_fault_detector/data_preprocessing/column_selector.py
@@ -1,10 +1,13 @@
 from typing import Optional, List
+import logging
 
 import numpy as np
 import pandas as pd
 from sklearn.utils.validation import check_is_fitted
 
 from energy_fault_detector.core.data_transformer import DataTransformer
+
+logger = logging.getLogger('energy_fault_detector')
 
 
 class ColumnSelector(DataTransformer):
@@ -40,16 +43,22 @@ class ColumnSelector(DataTransformer):
 
     # pylint: disable=attribute-defined-outside-init
     # noinspection PyAttributeOutsideInit
-    def fit(self, x: pd.DataFrame, y: Optional[np.array] = None) -> 'ColumnSelector':
+    def fit(self, x: pd.DataFrame, y: Optional[np.array] = None,
+            protected_features: Optional[List[str]] = None) -> 'ColumnSelector':
         """Find columns to keep for training
 
         Args:
             x: data to filter based on NaN fractions
             y: target variable, currently unused.
+            protected_features: list of feature names that should never be dropped (e.g., conditional features for
+                autoencoders). Warnings will be issued if these features would have been dropped otherwise.
         """
 
         self.feature_names_in_ = x.columns.to_list()
         self.n_features_in_ = len(x.columns)
+
+        protected_features = protected_features or []
+        protected_lower = [f.lower() for f in protected_features]
 
         # If features_to_select is provided - ignore upper/lower case
         if self.features_to_select is not None:
@@ -57,16 +66,34 @@ class ColumnSelector(DataTransformer):
             keep_cols = [col for col in x.columns if col.lower() in select_lower]
             x_transformed = x[keep_cols]
         else:
-            # drop features to exclude - ignore upper/lower case
+            # drop features to exclude - ignore upper/lower case, but protect protected_features
             to_drop = [col for col in x.columns if col.lower() in
                        [excluded_feature.lower() for excluded_feature in self.features_to_exclude]
                        ]
+
+            # Warn about protected features in exclusion list
+            protected_in_exclusion = [col for col in to_drop if col.lower() in protected_lower]
+            for col in protected_in_exclusion:
+                logger.warning(f"Feature '{col}' is in features_to_exclude but is used as a conditional feature. "
+                               f"Keeping it anyway.")
+                to_drop.remove(col)
+
             x_transformed = x.drop(to_drop, axis=1, errors='ignore')
 
         # drop columns which have more than max_nan_frac_per_col relative NaN frequency
         empty_percentage = x_transformed.isnull().mean(axis=0)
         empty_cols = empty_percentage[empty_percentage >= self.max_nan_frac_per_col].index
-        x_transformed = x_transformed.drop(empty_cols, axis=1)
+
+        # Protect features from NaN-based dropping
+        protected_empty_cols = [col for col in empty_cols if col.lower() in protected_lower]
+        for col in protected_empty_cols:
+            nan_frac = empty_percentage[col]
+            logger.warning(f"Feature '{col}' has {nan_frac*100:.1f}% NaN values (exceeds threshold of "
+                           f"{self.max_nan_frac_per_col*100:.1f}%), but is used as a conditional feature. "
+                           f"Keeping it anyway.")
+
+        empty_cols_to_drop = [col for col in empty_cols if col.lower() not in protected_lower]
+        x_transformed = x_transformed.drop(empty_cols_to_drop, axis=1)
 
         # select relevant numeric columns and set attribute for transform
         self.feature_names_out_ = x_transformed.columns.to_list()

--- a/energy_fault_detector/data_preprocessing/data_preprocessor.py
+++ b/energy_fault_detector/data_preprocessing/data_preprocessor.py
@@ -161,11 +161,13 @@ class DataPreprocessor(Pipeline, SaveLoadMixin):
 
         Args:
             x: Input DataFrame.
+            **kwargs: Parameters to pass to the fit method of each step.
+                Use step_name__parameter format (e.g., column_selector__protected_features=['feature1']).
 
         Returns:
             Transformed DataFrame with the same index as input.
         """
-        super().fit(X=x)
+        super().fit(X=x, **kwargs)
         return self.transform(x)
 
     def _find_step_by_type(self, types: Tuple[type, ...]) -> Tuple[Optional[str], Optional[object]]:

--- a/energy_fault_detector/data_preprocessing/data_preprocessor.py
+++ b/energy_fault_detector/data_preprocessing/data_preprocessor.py
@@ -156,6 +156,46 @@ class DataPreprocessor(Pipeline, SaveLoadMixin):
         return pd.DataFrame(data=x_, columns=self.get_feature_names_out(), index=x.index)
 
     # pylint: disable=arguments-renamed
+    def fit(self, X: pd.DataFrame, y=None, **fit_params):
+        """Fit all transformers in the pipeline.
+
+        Args:
+            X: Input DataFrame.
+            y: Target variable (optional).
+            **fit_params: Parameters to pass to the fit method of each step.
+                Use step_name__parameter format (e.g., column_selector__protected_features=['feature1']).
+                Special parameter 'protected_features' can be used to validate that these features
+                are present in the output after fitting.
+
+        Returns:
+            self
+
+        Raises:
+            ValueError: If protected_features are specified but not all are present in output.
+        """
+        # Extract protected features for validation (if provided)
+        protected_features = fit_params.pop('protected_features', None)
+
+        # Call parent fit
+        result = super().fit(X=X, y=y, **fit_params)
+
+        # Validate that protected features are in the output
+        if protected_features:
+            output_features = self.get_feature_names_out()
+            missing_features = [f for f in protected_features if f not in output_features]
+            if missing_features:
+                raise ValueError(
+                    f"Protected features were dropped by the preprocessing pipeline: {missing_features}. "
+                    f"This may be caused by AngleTransformer or CounterDiffTransformer modifying these features. "
+                    f"Please ensure protected features (e.g., conditional features for autoencoders) are not "
+                    f"transformed by these steps or consider the transformed version of these features (e.g. "
+                    f"<feature_name>_sin, <feature_name>_cos, <feature_name>_rate, <feature_name>_diff) as "
+                    f"conditional features."
+                )
+
+        return result
+
+    # pylint: disable=arguments-renamed
     def fit_transform(self, x: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
         """Fit and transform in one step.
 

--- a/energy_fault_detector/data_preprocessing/low_unique_value_filter.py
+++ b/energy_fault_detector/data_preprocessing/low_unique_value_filter.py
@@ -1,10 +1,13 @@
 from typing import Optional, List
+import logging
 
 import numpy as np
 import pandas as pd
 from sklearn.utils.validation import check_is_fitted
 
 from energy_fault_detector.core import DataTransformer
+
+logger = logging.getLogger('energy_fault_detector')
 
 
 class LowUniqueValueFilter(DataTransformer):
@@ -33,7 +36,8 @@ class LowUniqueValueFilter(DataTransformer):
 
     # pylint: disable=attribute-defined-outside-init
     # noinspection PyAttributeOutsideInit
-    def fit(self, x: pd.DataFrame, y: Optional[np.array] = None) -> 'LowUniqueValueFilter':
+    def fit(self, x: pd.DataFrame, y: Optional[np.array] = None,
+            protected_features: Optional[List[str]] = None) -> 'LowUniqueValueFilter':
         """Fit the LowUniqueValueFilter to the data.
 
         This method evaluates the features based on the number of unique values and the fraction of zeroes, and
@@ -42,6 +46,8 @@ class LowUniqueValueFilter(DataTransformer):
         Args:
             x (pd.DataFrame): The input data with features.
             y (Optional[np.array]): The target data (not used).
+            protected_features: list of feature names that should never be dropped (e.g., conditional features for
+                autoencoders). Warnings will be issued if these features would have been dropped otherwise.
 
         Returns:
             LowUniqueValueFilter: The fitted filter instance.
@@ -50,14 +56,37 @@ class LowUniqueValueFilter(DataTransformer):
         self.feature_names_in_ = x.columns.to_list()
         self.n_features_in_ = len(x.columns)
 
+        protected_features = protected_features or []
+        protected_lower = [f.lower() for f in protected_features]
+
         original_columns = x.columns
         counts = x.nunique()
         low_unique_count = counts[counts < self.min_unique_value_count].index
-        x = x.drop(low_unique_count, axis=1)
+
+        # Protect features from low unique value dropping
+        protected_low_unique = [col for col in low_unique_count if col.lower() in protected_lower]
+        for col in protected_low_unique:
+            unique_count = counts[col]
+            logger.warning(f"Feature '{col}' has only {unique_count} unique value(s) (below threshold of "
+                           f"{self.min_unique_value_count}), but is used as a conditional feature. "
+                           f"Keeping it anyway.")
+
+        low_unique_to_drop = [col for col in low_unique_count if col.lower() not in protected_lower]
+        x = x.drop(low_unique_to_drop, axis=1)
 
         zero_pct_per_column = (x == 0).mean(axis=0)
         columns_to_drop = zero_pct_per_column[zero_pct_per_column > self.max_col_zero_frac].index
-        x = x.drop(columns_to_drop, axis=1)
+
+        # Protect features from high zero fraction dropping
+        protected_high_zeros = [col for col in columns_to_drop if col.lower() in protected_lower]
+        for col in protected_high_zeros:
+            zero_frac = zero_pct_per_column[col]
+            logger.warning(f"Feature '{col}' has {zero_frac*100:.1f}% zeros (exceeds threshold of "
+                           f"{self.max_col_zero_frac*100:.1f}%), but is used as a conditional feature. "
+                           f"Keeping it anyway.")
+
+        high_zero_to_drop = [col for col in columns_to_drop if col.lower() not in protected_lower]
+        x = x.drop(high_zero_to_drop, axis=1)
 
         self.columns_dropped_ = [col for col in original_columns if col not in x.columns]
         self.feature_names_out_ = x.columns.to_list()

--- a/energy_fault_detector/fault_detector.py
+++ b/energy_fault_detector/fault_detector.py
@@ -66,22 +66,33 @@ class FaultDetector(FaultDetectionModel):
             raise ValueError('There are duplicated indices in the input dataframe `sensor_data` and/or in the '
                              '`normal_index`, please check your input data.')
 
+        # Get conditional features early to protect them from transformations
+        protected_features = self.autoencoder.conditional_features if self.autoencoder.is_conditional else []
+
         if self.config.data_clipping:
             logger.debug('Clip data before scaling.')
-            data_clipper = DataClipper(**self.config.data_clipping_params)
+            # Don't clip conditional features
+            clipper_params = self.config.data_clipping_params.copy()
+            if protected_features:
+                # Add conditional features to exclusion list
+                existing_exclusions = clipper_params.get('features_to_exclude', [])
+                clipper_params['features_to_exclude'] = list(set(existing_exclusions + protected_features))
+                logger.debug(f'Excluding conditional features from clipping: {protected_features}')
+            data_clipper = DataClipper(**clipper_params)
             data_clipper.fit(x=x)
             x = data_clipper.transform(x)
 
         x_normal = x[y.values]  # filter normal before data prep
         if fit_preprocessor:
             logger.info('Fit preprocessor pipeline.')
-            # Pass conditional features to protect them from being dropped
-            protected_features = self.autoencoder.conditional_features if self.autoencoder.is_conditional else []
             # Build fit params for pipeline steps that support protected_features
             fit_params = {}
             for step_name in self.data_preprocessor.named_steps.keys():
                 if 'column_selector' in step_name or 'low_unique_value_filter' in step_name:
                     fit_params[f'{step_name}__protected_features'] = protected_features
+            # Add global validation that protected features are in the output
+            if protected_features:
+                fit_params['protected_features'] = protected_features
             self.data_preprocessor.fit(x_normal, **fit_params)
 
         x_prepped = self.data_preprocessor.transform(x_normal)

--- a/energy_fault_detector/fault_detector.py
+++ b/energy_fault_detector/fault_detector.py
@@ -75,7 +75,14 @@ class FaultDetector(FaultDetectionModel):
         x_normal = x[y.values]  # filter normal before data prep
         if fit_preprocessor:
             logger.info('Fit preprocessor pipeline.')
-            self.data_preprocessor.fit(x_normal)
+            # Pass conditional features to protect them from being dropped
+            protected_features = self.autoencoder.conditional_features if self.autoencoder.is_conditional else []
+            # Build fit params for pipeline steps that support protected_features
+            fit_params = {}
+            for step_name in self.data_preprocessor.named_steps.keys():
+                if 'column_selector' in step_name or 'low_unique_value_filter' in step_name:
+                    fit_params[f'{step_name}__protected_features'] = protected_features
+            self.data_preprocessor.fit(x_normal, **fit_params)
 
         x_prepped = self.data_preprocessor.transform(x_normal)
 

--- a/tests/data_preprocessing/test_data_preprocessor.py
+++ b/tests/data_preprocessing/test_data_preprocessor.py
@@ -320,3 +320,98 @@ class TestDataPreprocessorPipelineWithTimestamp(TestCase):
         self.assertIn('minute_of_hour_sine', transformed.columns)
         self.assertIn('minute_of_hour_cosine', transformed.columns)
         self.assertIn('is_weekend', transformed.columns)
+
+
+class TestDataPreprocessorProtectedFeatures(TestCase):
+    """Test that protected features (e.g., conditional features for autoencoders) are never dropped."""
+
+    def setUp(self) -> None:
+        length = 10
+        time_index = pd.date_range(start='1/1/2021', end='10/1/2021', periods=length)
+        # Create test data where 'conditional_feature' would normally be dropped
+        data = {
+            'normal_feature': list(range(length)),
+            'conditional_feature': [1] * length,  # constant - would be dropped by LowUniqueValueFilter
+            'high_nan_feature': [None] * 8 + [1, 2],  # 80% NaN - would be dropped by ColumnSelector
+            'another_feature': list(range(length)),
+        }
+        self.test_data = pd.DataFrame(index=time_index, data=data)
+
+    def test_protected_feature_not_dropped_by_low_unique_value_filter(self):
+        """Test that a constant conditional feature is protected from LowUniqueValueFilter."""
+        preprocessor = DataPreprocessor(
+            steps=[
+                {'name': 'low_unique_value_filter',
+                 'params': {'min_unique_value_count': 2}},
+            ]
+        )
+
+        # Fit without protection - conditional_feature should be dropped
+        preprocessor.fit(self.test_data)
+        transformed = preprocessor.transform(self.test_data)
+        self.assertNotIn('conditional_feature', transformed.columns)
+
+        # Fit WITH protection - conditional_feature should be kept
+        preprocessor_protected = DataPreprocessor(
+            steps=[
+                {'name': 'low_unique_value_filter',
+                 'params': {'min_unique_value_count': 2}},
+            ]
+        )
+        fit_params = {'low_unique_value_filter__protected_features': ['conditional_feature']}
+        preprocessor_protected.fit(self.test_data, **fit_params)
+        transformed_protected = preprocessor_protected.transform(self.test_data)
+        self.assertIn('conditional_feature', transformed_protected.columns,
+                      "Protected feature should be kept despite being constant")
+
+    def test_protected_feature_not_dropped_by_column_selector(self):
+        """Test that a high-NaN conditional feature is protected from ColumnSelector."""
+        preprocessor = DataPreprocessor(
+            steps=[
+                {'name': 'column_selector',
+                 'params': {'max_nan_frac_per_col': 0.5}},  # 50% threshold
+            ]
+        )
+
+        # Fit without protection - high_nan_feature should be dropped (80% NaN > 50%)
+        preprocessor.fit(self.test_data)
+        transformed = preprocessor.transform(self.test_data)
+        self.assertNotIn('high_nan_feature', transformed.columns)
+
+        # Fit WITH protection - high_nan_feature should be kept
+        preprocessor_protected = DataPreprocessor(
+            steps=[
+                {'name': 'column_selector',
+                 'params': {'max_nan_frac_per_col': 0.5}},
+            ]
+        )
+        fit_params = {'column_selector__protected_features': ['high_nan_feature']}
+        preprocessor_protected.fit(self.test_data, **fit_params)
+        transformed_protected = preprocessor_protected.transform(self.test_data)
+        self.assertIn('high_nan_feature', transformed_protected.columns,
+                      "Protected feature should be kept despite high NaN percentage")
+
+    def test_protected_features_with_both_filters(self):
+        """Test that protected features work with both ColumnSelector and LowUniqueValueFilter."""
+        preprocessor = DataPreprocessor(
+            steps=[
+                {'name': 'column_selector',
+                 'params': {'max_nan_frac_per_col': 0.5}},
+                {'name': 'low_unique_value_filter',
+                 'params': {'min_unique_value_count': 2}},
+            ]
+        )
+
+        # Protect both problematic features
+        fit_params = {
+            'column_selector__protected_features': ['high_nan_feature', 'conditional_feature'],
+            'low_unique_value_filter__protected_features': ['high_nan_feature', 'conditional_feature']
+        }
+        preprocessor.fit(self.test_data, **fit_params)
+        transformed = preprocessor.transform(self.test_data)
+
+        # Both protected features should be present
+        self.assertIn('conditional_feature', transformed.columns,
+                      "Constant protected feature should be kept")
+        self.assertIn('high_nan_feature', transformed.columns,
+                      "High-NaN protected feature should be kept")

--- a/tests/data_preprocessing/test_data_preprocessor.py
+++ b/tests/data_preprocessing/test_data_preprocessor.py
@@ -415,3 +415,24 @@ class TestDataPreprocessorProtectedFeatures(TestCase):
                       "Constant protected feature should be kept")
         self.assertIn('high_nan_feature', transformed.columns,
                       "High-NaN protected feature should be kept")
+
+    def test_validation_fails_when_protected_feature_missing_from_output(self):
+        """Test that fit raises ValueError if a protected feature is missing from output."""
+        from energy_fault_detector.data_preprocessing.angle_transformer import AngleTransformer
+
+        # Create a pipeline that transforms a protected feature
+        preprocessor = DataPreprocessor(
+            steps=[
+                {'name': 'angle_transformer',
+                 'params': {'angles': ['conditional_feature']}},  # Transforms conditional_feature
+            ]
+        )
+
+        # This should raise an error because 'conditional_feature' will be transformed to
+        # 'conditional_feature_sin' and 'conditional_feature_cos'
+        with self.assertRaises(ValueError) as context:
+            preprocessor.fit(self.test_data, protected_features=['conditional_feature'])
+
+        self.assertIn('Protected features were dropped', str(context.exception))
+        self.assertIn('conditional_feature', str(context.exception))
+        self.assertIn('AngleTransformer or CounterDiffTransformer', str(context.exception))

--- a/tests/test_fault_detector.py
+++ b/tests/test_fault_detector.py
@@ -184,6 +184,8 @@ class TestFaultDetector(unittest.TestCase):
         mock_data_preprocessor.transform.side_effect = [self.sensor_data[self.normal_index],
                                                         self.sensor_data]
         mock_autoencoder.get_reconstruction_error.side_effect = [self.recon_error, self.recon_error, self.recon_error]
+        mock_autoencoder.conditional_features = []
+        mock_autoencoder.is_conditional = False
         mock_score.transform.side_effect = [pd.Series([0.1, 0.2, 0.15])] * 2
 
         results = fault_detector.fit(sensor_data=self.sensor_data,
@@ -225,6 +227,7 @@ class TestFaultDetector(unittest.TestCase):
         mock_data_preprocessor.transform.side_effect = [self.sensor_data[self.normal_index],
                                                         self.sensor_data]
         mock_autoencoder.get_reconstruction_error.side_effect = [self.recon_error] * 9
+        mock_autoencoder.is_conditional = False
         mock_score.transform.side_effect = [pd.Series([0.1, 0.2, 0.15])] * 3
         mock_data_preprocessor.transform.side_effect = [self.sensor_data[self.normal_index],
                                                         self.sensor_data]

--- a/tests/test_fault_detector.py
+++ b/tests/test_fault_detector.py
@@ -483,3 +483,45 @@ class TestAutoencoderGetReconstructionError(unittest.TestCase):
         with patch.object(ae, 'predict', return_value=self.reconstruction) as mock_predict:
             result = ae.get_reconstruction_error(self.sensor_data)
             mock_predict.assert_called_once()
+
+
+class TestFaultDetectorConditionalFeatureProtection(unittest.TestCase):
+    """Test that FaultDetector protects conditional features from being dropped during preprocessing."""
+
+    def setUp(self) -> None:
+        self.config_path = os.path.join(PROJECT_ROOT, 'tests/test_data/test_conditional_ae_config.yaml')
+        self.conf = Config(self.config_path)
+        self.test_dir = tempfile.mkdtemp()
+
+        # Create sensor data where conditional feature is constant (would normally be dropped)
+        np.random.seed(42)
+        length = 100
+        self.sensor_data = pd.DataFrame({
+            'feature_a': [180] * length,  # Constant conditional feature
+            'feature_b': np.random.random(size=length),
+            'feature_c': np.random.random(size=length),
+            'feature_d': np.random.random(size=length),
+        })
+        self.normal_index = pd.Series([True] * 80 + [False] * 20)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_conditional_features_protected_from_dropping(self):
+        """Test that conditional features specified in the autoencoder are protected during fit."""
+        # The config specifies ConditionalAE with 'feature_a' as conditional feature
+        # It also has LowUniqueValueFilter which would normally drop constant features
+        fault_detector = FaultDetector(config=self.conf, model_directory=self.test_dir)
+
+        # Fit the model - this should NOT drop the conditional feature despite it being constant
+        fault_detector.fit(sensor_data=self.sensor_data, normal_index=self.normal_index, save_models=False)
+
+        # Check that the conditional feature is still present after preprocessing
+        feature_names = fault_detector.data_preprocessor.get_feature_names_out()
+        self.assertIn('feature_a', feature_names,
+                      "Conditional feature 'feature_a' should be protected from dropping")
+
+        # Verify we can predict with data containing the conditional feature
+        result = fault_detector.predict(sensor_data=self.sensor_data)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result.predicted_anomalies), len(self.sensor_data))


### PR DESCRIPTION
Conditional features for autoencoders (e.g., `status` for ConditionalAE) could be accidentally dropped by preprocessing steps:
- **ColumnSelector**: dropped if in `features_to_exclude` or if NaN percentage > threshold
- **LowUniqueValueFilter**: dropped if constant or low variance (e.g., `status=1` for all training data)
- **DataClipper**: could clip conditional features, altering their values
- **AngleTransformer/CounterDiffTransformer**: could transform conditional features, breaking the pipeline

This caused silent failures where models would fail during fit/predict due to missing conditional features.

- **Added `protected_features` parameter** to `ColumnSelector.fit()` and `LowUniqueValueFilter.fit()`
   - Protected features are never dropped
   - Warnings issued when protected features would have been dropped (alerts users to data quality issues)

- **DataPreprocessor validation**
   - Added `fit()` override that validates protected features are present in output
   - Raises clear error if protected features missing (e.g., transformed by AngleTransformer)

- **FaultDetector integration**
   - Automatically extracts `conditional_features` from autoencoder
   - Passes them as protected to ColumnSelector and LowUniqueValueFilter via sklearn's `step_name__parameter` convention
   - Excludes them from DataClipper to prevent clipping
   - Validates all conditional features present after preprocessing
